### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Audio-Tool-Ideas
+
+This repository contains early experiments for audio processing tools.
+
+## Development
+
+Install the pre-commit hooks after cloning:
+
+```bash
+pre-commit install
+```


### PR DESCRIPTION
## Summary
- add pre-commit hooks for `black`, `isort`, `flake8`, and `pytest`
- document pre-commit installation in the README

## Testing
- `pre-commit run --all-files` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68448b57bbbc832697a61ad2ea94ba09